### PR TITLE
check for valid JSON

### DIFF
--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -297,7 +297,14 @@ class Version1X extends AbstractSocketIO
 
             switch ($packet->proto) {
                 case static::PROTO_MESSAGE:
-                    if (null !== ($data = json_decode($seq->getData(), true))) {
+                    $data = $seq->getData();
+                    // make sure it really is valid JSON
+                    preg_match('#\{(?:[^{}]|(?R))*\}#s', $data, $matches);
+                    if(\count($matches) && $matches[0]){
+                        $data = $matches[0];
+                    }
+
+                    if (null !== ($data = json_decode($data, true))) {
                         switch ($packet->type) {
                             case static::PACKET_EVENT:
                                 $packet->event = array_shift($data);


### PR DESCRIPTION
My Socket.IO v4 Server response for the namespace confirmation was always something like

```
{"sid":"JoSL0DC6A4HghxIWDBtU"}-41
```
instead of 
```
{"sid":"JoSL0DC6A4HghxIWDBtU"}
```
So your 
```PHP
if (null !== ($data = json_decode($seq->getData(), true))) {
```
always failed since it's no valid JSON.

All I did was to confirm it always contains valid JSON and strip other data.
```PHP
$data = $seq->getData();
// make sure it really is valid JSON
preg_match('#\{(?:[^{}]|(?R))*\}#s', $data, $matches);
if(\count($matches) && $matches[0]){
    $data = $matches[0];
}
```

Let me know if I missed anything. However with these lines everything works for me now.