### PR TITLE
add socket.io's handshake.auth option

### DIFF
--- a/example/handshake-auth/client/client.php
+++ b/example/handshake-auth/client/client.php
@@ -10,7 +10,7 @@
  * @license   http://www.opensource.org/licenses/MIT-License MIT License
  */
 
-use ElephantIO\Client;;
+use ElephantIO\Client;
 
 use ElephantIO\Exception\ServerConnectionFailureException;
 use Monolog\Logger;

--- a/example/handshake-auth/client/client.php
+++ b/example/handshake-auth/client/client.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the Elephant.io package
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @copyright Wisembly
+ * @license   http://www.opensource.org/licenses/MIT-License MIT License
+ */
+
+use ElephantIO\Client;;
+
+use ElephantIO\Exception\ServerConnectionFailureException;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+$version = Client::CLIENT_4X;
+$url = 'http://localhost:1334';
+$event = 'echo';
+
+$logfile = __DIR__ . '/socket.log';
+
+if (is_readable($logfile)) {
+    @unlink($logfile);
+}
+// create a log channel
+$logger = new Logger('client');
+$logger->pushHandler(new StreamHandler($logfile, Logger::DEBUG));
+
+echo sprintf("Creating first socket to %s\n", $url);
+// create first instance
+$client = new Client(Client::engine($version, $url, [
+    'auth' => [
+        'user' => 'random@example.com',
+        'token' => 'my-secret-token',
+    ]
+]), $logger);
+$client->initialize();
+
+$data = [
+    'message' => 'Hello!'
+];
+echo sprintf("Sending message: %s\n", json_encode($data));
+$client->emit($event, $data);
+if ($retval = $client->wait($event)) {
+    echo sprintf("Got a reply: %s\n", json_encode($retval->data));
+}
+$client->close();
+
+// create second instance
+echo sprintf("Creating second socket to %s\n", $url);
+$client = new Client(Client::engine($version, $url, [
+    'auth' => [
+        'user' => 'random@example.com',
+        'password' => 'my-wrong-secret-password',
+    ]
+]), $logger);
+try {
+    $client->initialize();
+} catch (ServerConnectionFailureException $e) {
+    echo sprintf("Authentication successfully failed with invalid credentials");
+}
+
+
+// close connection
+$client->close();

--- a/example/handshake-auth/server/package.json
+++ b/example/handshake-auth/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "elephant-io_example_handshake-auth",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "socket.io": "^4.7.1"
+  }
+}

--- a/example/handshake-auth/server/server.js
+++ b/example/handshake-auth/server/server.js
@@ -1,0 +1,47 @@
+/**
+ * This file is part of the Elephant.io package
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ *
+ * @copyright Wisembly
+ * @license   http://www.opensource.org/licenses/MIT-License MIT License
+ */
+
+const server = require('http').createServer();
+const io = require('socket.io')(server);
+
+const port = 1334;
+
+
+// set up initialization and authorization method
+io.use((socket, next) => {
+  const user = socket.handshake.auth.user;
+  const token = socket.handshake.auth.token;
+  if(user && token) {
+    console.log('auth token', token);
+    // do some security check with token
+    // for example:
+    if (user === 'random@example.com' && token === 'my-secret-token') {
+      console.log('Successfully authenticated');
+      return next();
+    }
+
+    return next(new Error('invalid credentials'));
+  } else{
+    return next(new Error('missing auth from the handshake'));
+  }
+});
+
+io.on('connection', socket => {
+  socket.on('echo', message => {
+    socket.emit('echo', message);
+  });
+  socket.on('disconnect', () => {
+    console.log('SocketIO > Disconnected socket');
+  });
+});
+
+server.listen(port, () => {
+  console.log('Server listening at %d...', port);
+});

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -456,6 +456,14 @@ class Version1X extends AbstractSocketIO
         ]);
         $payload = static::PROTO_MESSAGE . static::PACKET_CONNECT;
 
+        if ($this->options['auth']) {
+            $encodedAuthPayload = json_encode($this->options['auth']);
+            if ($encodedAuthPayload === false) {
+                throw new Exception('Can\'t parse auth option to JSON: ' . json_last_error_msg());
+            }
+            $payload .= $encodedAuthPayload;
+        }
+
         $this->stream->request($uri, ['Connection: close'], ['method' => 'POST', 'payload' => $payload]);
         if ($this->stream->getStatusCode() != 200) {
             throw new ServerConnectionFailureException('unable to perform namespace request');

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -176,7 +176,7 @@ class Version1X extends AbstractSocketIO
         if ($oldns != $namespace) {
             parent::of($namespace);
 
-            $this->send(static::PROTO_MESSAGE, static::PACKET_CONNECT . $namespace);
+            $this->send(static::PROTO_MESSAGE, static::PACKET_CONNECT . $namespace . $this->getAuthPayload($namespace));
 
             return $this->drain();
         }
@@ -454,15 +454,7 @@ class Version1X extends AbstractSocketIO
             't'         => Yeast::yeast(),
             'sid'       => $this->session->id,
         ]);
-        $payload = static::PROTO_MESSAGE . static::PACKET_CONNECT;
-
-        if ($this->options['auth']) {
-            $encodedAuthPayload = json_encode($this->options['auth']);
-            if ($encodedAuthPayload === false) {
-                throw new Exception('Can\'t parse auth option to JSON: ' . json_last_error_msg());
-            }
-            $payload .= $encodedAuthPayload;
-        }
+        $payload = static::PROTO_MESSAGE . static::PACKET_CONNECT . $this->getAuthPayload();
 
         $this->stream->request($uri, ['Connection: close'], ['method' => 'POST', 'payload' => $payload]);
         if ($this->stream->getStatusCode() != 200) {
@@ -470,6 +462,24 @@ class Version1X extends AbstractSocketIO
         }
 
         $this->logger->debug('Requesting namespace completed');
+    }
+
+    protected function getAuthPayload($namespace = '/')
+    {
+        if (!$this->options['auth'] || $this->options['version'] < 4) {
+            return '';
+        }
+
+        $encodedAuthPayload = json_encode($this->options['auth']);
+        if ($encodedAuthPayload === false) {
+            throw new Exception('Can\'t parse auth option to JSON: ' . json_last_error_msg());
+        }
+
+        $preString = '';
+        if ($namespace && $namespace !== '' && $namespace !== '/') {
+            $preString = ',';
+        }
+        return $preString . $encodedAuthPayload;
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for Socket.io's handshake authentication feature, as outlined in the [Socket.io documentation](https://socket.io/docs/v4/middlewares/#sending-credentials). The proposed changes ensure that Elephant.io can seamlessly integrate with Socket.io servers that require authentication during the handshake phase.

Usage example:
```php
$engine = Client::engine(
    Client::CLIENT_4X,
    $socketAddress,
    [
        'auth' => [
            "token" => 'my_secret_token',
            "user" => 'admin@example.com',
        ],
    ]
);
$this->client = new Client($engine);
$this->client->initialize();
```
