### PR TITLE
set headers as an associative array

### DIFF
--- a/example/emitter-with-private-socket-id/client/client_deprecated.php
+++ b/example/emitter-with-private-socket-id/client/client_deprecated.php
@@ -31,12 +31,13 @@ $logger = new Logger('client');
 $logger->pushHandler(new StreamHandler($logfile, Logger::DEBUG));
 
 echo sprintf("Creating first socket to %s\n", $url);
+
 // create first instance
 $client = new Client(Client::engine($version, $url, [
     'headers' => [
-        'X-My-Header' => 'websocket rocks',
-        'Authorization' => 'Bearer ' . $token,
-        'User' => 'peter',
+        'X-My-Header: websocket rocks',
+        'Authorization: Bearer ' . $token,
+        'User: peter',
     ]
 ]), $logger);
 $client->initialize();
@@ -56,9 +57,9 @@ $client->close();
 echo sprintf("Creating second socket to %s\n", $url);
 $client = new Client(Client::engine($version, $url, [
     'headers' => [
-        'X-My-Header' => 'websocket rocks',
-        'Authorization' => 'Bearer ' . $token,
-        'User' => 'peter',
+        'X-My-Header: websocket rocks',
+        'Authorization: Bearer ' . $token,
+        'User: peter',
     ]
 ]), $logger);
 $client->initialize();

--- a/src/Engine/AbstractSocketIO.php
+++ b/src/Engine/AbstractSocketIO.php
@@ -61,6 +61,14 @@ abstract class AbstractSocketIO implements EngineInterface
     {
         $this->url = $url;
 
+        if (isset($options['headers'])) {
+            $this->handleDeprecatedHeaderOptions($options['headers']);
+        }
+
+        if (isset($options['context']['headers'])) {
+            $this->handleDeprecatedHeaderOptions($options['context']['headers']);
+        }
+
         if (isset($options['context'])) {
             $this->context = $options['context'];
             unset($options['context']);
@@ -266,6 +274,34 @@ abstract class AbstractSocketIO implements EngineInterface
     public function getName()
     {
         return 'SocketIO';
+    }
+
+    /**
+     * Handles deprecated header options in an array
+     *
+     * This function checks the format of the provided array of headers. If the headers are in the old
+     * non-associative format (numeric indexed), it triggers a deprecated warning and converts them
+     * to the new key-value array format.
+     *
+     * @param array $headers A reference to the array of HTTP headers to be processed. This array may
+     *                      be modified if the headers are in the deprecated format.
+     *
+     * @return void This function modifies the input array in place and does not return any value.
+     */
+    protected function handleDeprecatedHeaderOptions(&$headers)
+    {
+        if (is_array($headers) && count($headers) > 0) {
+            // Check if the array is not associative (indicating old format)
+            if (array_values($headers) == $headers) {
+                trigger_error('You are using a deprecated header format. Please update to the new key-value array format.', E_USER_DEPRECATED);
+                $newHeaders = [];
+                foreach ($headers as $header) {
+                    list($key, $value) = explode(': ', $header, 2);
+                    $newHeaders[$key] = $value;
+                }
+                $headers = $newHeaders; // Convert to new format
+            }
+        }
     }
 
     /**

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -188,7 +188,7 @@ class Version0X extends AbstractSocketIO
             $uri .= '/?' . http_build_query($url['query']);
         }
 
-        $this->stream->request($uri, ['Connection: close']);
+        $this->stream->request($uri, ['Connection' => 'close']);
         if ($this->stream->getStatusCode() != 200) {
             throw new ServerConnectionFailureException('unable to perform handshake');
         }
@@ -236,27 +236,18 @@ class Version0X extends AbstractSocketIO
 
         $key = \base64_encode(\sha1(\uniqid(\mt_rand(), true), true));
 
-        $origin = '*';
-        $headers = isset($this->context['headers']) ? (array) $this->context['headers'] : [] ;
-
-        foreach ($headers as $header) {
-            $matches = [];
-            if (\preg_match('`^Origin:\s*(.+?)$`', $header, $matches)) {
-                $origin = $matches[1];
-                break;
-            }
-        }
+        $origin = $this->context['headers']['Origin'] ?? '*';
 
         $headers = [
-            'Upgrade: WebSocket',
-            'Connection: Upgrade',
-            sprintf('Sec-WebSocket-Key: %s', $key),
-            'Sec-WebSocket-Version: 13',
-            sprintf('Origin: %s', $origin),
+            'Upgrade' => 'WebSocket',
+            'Connection' => 'Upgrade',
+            'Sec-WebSocket-Key' => $key,
+            'Sec-WebSocket-Version' => '13',
+            'Origin' => $origin,
         ];
 
         if (!empty($this->cookies)) {
-            $headers[] = sprintf('Cookie: %s', implode('; ', $this->cookies));
+            $headers['Cookie'] = implode('; ', $this->cookies);
         }
         $this->stream->request($uri, $headers, ['skip_body' => true]);
         if ($this->stream->getStatusCode() != 101) {


### PR DESCRIPTION
## Refactor: Allow setting headers as an associative array

In this commit, I have refactored the code to enable the use of associative arrays for setting headers in the `$options['headers']` and the `$options['context']['headers']` configurations. Previously, headers were defined as a list of strings, but now you can use key-value pairs for a more intuitive and maintainable approach.


## Usage
**Before** _(DEPRECATED):_ 
```php
$client = new Client(Client::engine($version, $url, [
    'headers' => [
        'X-My-Header: websocket rocks',
        sprintf('Authorization: %s ' . $token),
        sprintf('User: %s', $userName),
    ]
]), $logger);
```

**After:**
```php
$client = new Client(Client::engine($version, $url, [
    'headers' => [
        'X-My-Header' => 'websocket rocks',
        'Authorization' => $token,
        'User' => $userName,
    ]
]), $logger);
```


## Refactor's reasons:

1. **Improved Readability and Maintainability:** With this enhancement, we can define headers using key-value pairs, eliminating the need for string manipulation operations (e.g., substring, sprintf, regex) to format and read headers. This results in cleaner and more readable code.

2. **Alignment with Modern Practices:** Many modern HTTP client libraries, including popular ones like Axios in the JavaScript world, utilize headers as key-value pairs. By adopting this approach, the codebase aligns with contemporary development practices, making it more accessible to developers familiar with these standards.

3. **Flexibility in Header Customization:** This change provides a straightforward way to override the 'Host' header. For instance, it allows you to specify a custom 'Host' when connecting directly to an IP address. This added flexibility simplifies scenarios where fine-grained control over headers is required.
