### PR TITLE
feat: support websocket transport (#1)

### DIFF
--- a/src/Stream/SocketStream.php
+++ b/src/Stream/SocketStream.php
@@ -211,13 +211,13 @@ class SocketStream extends AbstractStream
 
         // wait for response
         $header = true;
-        $len = null;
+        $len = 4096;
         $this->logger->debug('Waiting for response!!!');
         while (true) {
             if (!$this->connected()) {
                 break;
             }
-            if ($content = $header ? fgets($this->handle) : fread($this->handle, (int) $len)) {
+            if ($content = $header ? fgets($this->handle) : fread($this->handle, $len)) {
                 $this->logger->debug(sprintf('Receive: %s', trim($content)));
                 if ($content === static::EOL && $header) {
                     if ($skip_body) {


### PR DESCRIPTION
Hi there,

When transport is set to "websocket", no handshake are needed, and no session is required.

This is sort of a follow up from that old PR: https://github.com/Wisembly/elephant.io/pull/197/files

This PR solves for this, and also adds a very limited amount of refactoring around the modified lines.

Please note that the change to `src/Stream/SocketStream.php` is not a typo. I'm getting the following error without this change: 
`Fatal error: Uncaught ValueError: fread(): Argument #2 ($length) must be greater than 0 in /app/vendor/elephantio/elephant.io/src/Stream/SocketStream.php:220`.  
Not sure if this is because of  "websocket" being the transport I use, or because of php8, but I believe this should work for all platforms.


Note: the server I am connecting to is using `"socket.io": "^1.4.6"`