### PR TITLE
Add PHP 8.2 compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,8 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
 
     steps:
     - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     },
     "require": {
         "php": ">=7.2",
+        "ext-mbstring": "*",
         "psr/log": "^1.1 || ^3.0"
     },
     "require-dev": {

--- a/src/Stream/SocketStream.php
+++ b/src/Stream/SocketStream.php
@@ -189,7 +189,7 @@ class SocketStream extends AbstractStream
             $contentType = $headers['Content-type'] ?? null;
 
             if (null === $contentType) {
-                $payload = utf8_encode($payload);
+                $payload = mb_convert_encoding($payload, 'UTF-8', 'ISO-8859-1');
                 $headers['Content-type'] = 'text/plain;charset=UTF-8';
                 $headers['Content-Length'] = strlen($payload);
             }


### PR DESCRIPTION
Function `utf8_encode()` is deprecated since PHP 8.2 https://www.php.net/manual/en/function.utf8-encode.php

I'm not sure why it is being used here, but to keep the current behavior, I replaced it with `mb_convert_encoding()`