### PR TITLE
Use an array for values instead of dynamic properties (PHP 8.2 compat)

### DIFF
--- a/src/Engine/Packet.php
+++ b/src/Engine/Packet.php
@@ -58,10 +58,9 @@ class Packet extends Store
     {
         $result = [];
         $result[] = $this;
-        if (isset($this->next)) {
-            foreach ($this->next as $p) {
-                $result = array_merge($result, $p->flatten());
-            }
+
+        foreach ((array) $this->next as $p) {
+            $result = array_merge($result, $p->flatten());
         }
 
         return $result;
@@ -90,10 +89,11 @@ class Packet extends Store
      */
     public function add($packet)
     {
-        if (!isset($this->next)) {
-            $this->next = [];
+        if (!$this->next) {
+            $this->next = [$packet];
+        } else {
+            $this->next = array_merge($this->next, [$packet]);
         }
-        $this->next[] = $packet;
 
         return $this;
     }

--- a/src/Engine/Store.php
+++ b/src/Engine/Store.php
@@ -34,6 +34,13 @@ class Store
     protected $keys = [];
 
     /**
+     * Store values.
+     *
+     * @var mixed[]
+     */
+    protected $values = [];
+
+    /**
      * Key flags.
      *
      * @var string[]
@@ -137,7 +144,7 @@ class Store
         $result = [];
         foreach ($this->keys as $key) {
             $key = $this->getNormalizedKey($key);
-            if (isset($this->$key)) {
+            if (isset($this->values[$key])) {
                 $result[$key] = $this->$key;
             }
         }
@@ -170,7 +177,7 @@ class Store
     {
         $key = $this->getKey($key);
 
-        return isset($this->$key) ? $this->$key : null;
+        return isset($this->values[$key]) ? $this->values[$key] : null;
     }
 
     /**
@@ -183,7 +190,7 @@ class Store
     public function __set($key, $value)
     {
         $key = $this->getKey($key);
-        $this->$key = $value;
+        $this->values[$key] = $value;
 
         return $this;
     }
@@ -203,7 +210,7 @@ class Store
                     $title = $this->getMappedValue($key, $this->$key);
                     break;
                 default:
-                    if (isset($this->$key)) {
+                    if (isset($this->values[$key])) {
                         $value = $this->getMappedValue($key, $this->$key);
                         if (null !== $value && ($flag !== '!' || null === $xclusive)) {
                             $items[$key] = $value;


### PR DESCRIPTION
This fixes deprecation warnings found:

```
PHP Deprecated:  Creation of dynamic property ElephantIO\Engine\Packet::$proto is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186
PHP Deprecated:  Creation of dynamic property ElephantIO\Engine\Packet::$proto is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186
PHP Deprecated:  Creation of dynamic property ElephantIO\Engine\Packet::$next is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186
...
```