### PR TITLE
Fix dynamic property deprecation for PHP 8.2

### DIFF
--- a/src/Engine/Packet.php
+++ b/src/Engine/Packet.php
@@ -58,10 +58,9 @@ class Packet extends Store
     {
         $result = [];
         $result[] = $this;
-        if (isset($this->next)) {
-            foreach ($this->next as $p) {
-                $result = array_merge($result, $p->flatten());
-            }
+
+        foreach ((array) $this->next as $p) {
+            $result = array_merge($result, $p->flatten());
         }
 
         return $result;
@@ -90,10 +89,11 @@ class Packet extends Store
      */
     public function add($packet)
     {
-        if (!isset($this->next)) {
-            $this->next = [];
+        if (!$this->next) {
+            $this->next = [$packet];
+        } else {
+            $this->next = array_merge($this->next, [$packet]);
         }
-        $this->next[] = $packet;
 
         return $this;
     }

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -100,7 +100,7 @@ class Version1X extends SocketIO
                     if (null === $bindata) {
                         throw new RuntimeException(sprintf('Binary data unavailable for index %d!', $i));
                     }
-                    $this->replaceAttachment($packet->data, $i, $bindata);
+                    $packet->data = $this->replaceAttachment($packet->data, $i, $bindata);
                 }
             }
             switch ($packet->proto) {
@@ -362,8 +362,9 @@ class Version1X extends SocketIO
      * @param array $array
      * @param int $index
      * @param string $data
+     * @return array
      */
-    protected function replaceAttachment(&$array, $index, $data)
+    protected function replaceAttachment($array, $index, $data)
     {
         if (is_array($array)) {
             foreach ($array as $key => &$value) {
@@ -376,11 +377,12 @@ class Version1X extends SocketIO
                         }
                         $this->logger->debug(sprintf('Replacing binary attachment for %d (%s)', $index, $key));
                     } else {
-                        $this->replaceAttachment($value, $index, $data);
+                        $value = $this->replaceAttachment($value, $index, $data);
                     }
                 }
             }
         }
+        return $array;
     }
 
     /**

--- a/src/Engine/Store.php
+++ b/src/Engine/Store.php
@@ -34,6 +34,13 @@ class Store
     protected $keys = [];
 
     /**
+     * Store values.
+     *
+     * @var mixed[]
+     */
+    protected $values = [];
+
+    /**
      * Key flags.
      *
      * @var string[]
@@ -137,7 +144,7 @@ class Store
         $result = [];
         foreach ($this->keys as $key) {
             $key = $this->getNormalizedKey($key);
-            if (isset($this->$key)) {
+            if (isset($this->values[$key])) {
                 $result[$key] = $this->$key;
             }
         }
@@ -170,7 +177,7 @@ class Store
     {
         $key = $this->getKey($key);
 
-        return isset($this->$key) ? $this->$key : null;
+        return isset($this->values[$key]) ? $this->values[$key] : null;
     }
 
     /**
@@ -183,7 +190,7 @@ class Store
     public function __set($key, $value)
     {
         $key = $this->getKey($key);
-        $this->$key = $value;
+        $this->values[$key] = $value;
 
         return $this;
     }
@@ -203,7 +210,7 @@ class Store
                     $title = $this->getMappedValue($key, $this->$key);
                     break;
                 default:
-                    if (isset($this->$key)) {
+                    if (isset($this->values[$key])) {
                         $value = $this->getMappedValue($key, $this->$key);
                         if (null !== $value && ($flag !== '!' || null === $xclusive)) {
                             $items[$key] = $value;

--- a/src/Engine/Store.php
+++ b/src/Engine/Store.php
@@ -193,6 +193,17 @@ class Store
         $this->values[$key] = $value;
     }
 
+    /**
+     * Check if key exists.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        $key = $this->getKey($key);
+
+        return isset($this->values[$key]);
     }
 
     public function __toString()

--- a/src/Engine/Store.php
+++ b/src/Engine/Store.php
@@ -185,14 +185,14 @@ class Store
      *
      * @param string $key
      * @param mixed $value
-     * @return \ElephantIO\Engine\Store
+     * @return void
      */
     public function __set($key, $value)
     {
         $key = $this->getKey($key);
         $this->values[$key] = $value;
+    }
 
-        return $this;
     }
 
     public function __toString()


### PR DESCRIPTION
PHP 8.2+ compatibility eg.

```
Deprecated: Creation of dynamic property ElephantIO\Engine\Session::$heartbeat is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186
PHP Deprecated:  Creation of dynamic property ElephantIO\Engine\Packet::$proto is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186

Deprecated: Creation of dynamic property ElephantIO\Engine\Packet::$proto is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186
PHP Deprecated:  Creation of dynamic property ElephantIO\Engine\Packet::$data is deprecated in /Users/adamroyle/Projects/elephant.io/src/Engine/Store.php on line 186
...
```