### PR TITLE
Throw exceptions on errors, warnings and notices in examples

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -61,6 +61,8 @@ jobs:
 
     - name: Run examples
       run: |
+        PHP_VERSION_SUFFIX=$(echo "${{ matrix.php-version }}" | tr -d '.') # Remove dots from PHP version
+        export PORT=140$PHP_VERSION_SUFFIX # Assign a unique port for each PHP version
         cd example/server && node index.js &
         sleep 5
         cd example/client

--- a/example/client/common.php
+++ b/example/client/common.php
@@ -18,6 +18,24 @@ use Psr\Log\LogLevel;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+error_reporting(E_ALL);
+set_error_handler('error_to_exception');
+
+/**
+ * Throw exceptions for all unhandled errors, deprecations and warnings while running the examples.
+ *
+ * @param int $code
+ * @param string $message
+ * @param string $filename
+ * @param int $line
+ * @return void
+ */
+function error_to_exception($code, $message, $filename, $line) {
+    if (error_reporting() & $code) {
+        throw new ErrorException($message, 0, $code, $filename, $line);
+    }
+}
+
 /**
  * Get or set client version to use.
  *
@@ -61,7 +79,7 @@ function setup_logger()
  */
 function setup_client($namespace, $logger = null, $options = [])
 {
-    $url = 'http://localhost:14000';
+    $url = 'http://localhost:' . (getenv('PORT') ?: 14000);
     if (isset($options['url'])) {
         $url = $options['url'];
         unset($options['url']);

--- a/example/server/index.js
+++ b/example/server/index.js
@@ -14,7 +14,7 @@ const server = require('http').createServer();
 const socketio = require('socket.io');
 const io = typeof socketio === 'function' ? socketio(server) : socketio.listen(server);
 
-const port = 14000;
+const port = Number(process.env.PORT) || 14000;
 const dir = __dirname;
 
 console.log('Please wait, running servers...');


### PR DESCRIPTION
The change surfaces warnings and notices during continuous integration workflow, causing the workflow to fail. This will help catch any errors with future PHP versions.

Once this is merged can you please tag a new patch version so #15 can be used?