### PR TITLE
fix: Use timeout config for multiple operations

### DIFF
--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -395,7 +395,7 @@ class Version1X extends SocketIO
 
         /** @var \ElephantIO\Engine\Transport\Polling $transport */
         $transport = $this->_transport();
-        if (null === ($data = $transport->recv(0, ['upgrade' => $this->transport === static::TRANSPORT_WEBSOCKET]))) {
+        if (null === ($data = $transport->recv($this->options->timeout, ['upgrade' => $this->transport === static::TRANSPORT_WEBSOCKET]))) {
             throw new ServerConnectionFailureException('unable to perform handshake');
         }
 
@@ -447,7 +447,7 @@ class Version1X extends SocketIO
         // set timeout based on handshake response
         $this->setTimeout($this->session->getTimeout());
 
-        if (null !== $this->_transport()->recv(0, ['transport' => static::TRANSPORT_WEBSOCKET, 'upgrade' => true])) {
+        if (null !== $this->_transport()->recv($this->options->timeout, ['transport' => static::TRANSPORT_WEBSOCKET, 'upgrade' => true])) {
             $this->setTransport(static::TRANSPORT_WEBSOCKET);
             $this->stream->upgrade();
 

--- a/src/Engine/SocketIO/Version1X.php
+++ b/src/Engine/SocketIO/Version1X.php
@@ -401,7 +401,7 @@ class Version1X extends SocketIO
 
         if ($this->transport === static::TRANSPORT_WEBSOCKET) {
             $this->stream->upgrade();
-            $packet = $this->drain();
+            $packet = $this->drain($this->options->timeout);
         } else {
             $packet = $this->processData($data);
         }
@@ -454,7 +454,7 @@ class Version1X extends SocketIO
             $this->send(static::PROTO_UPGRADE);
 
             // ensure got packet connect on socket.io 1.x
-            if ($this->options->version === static::EIO_V2 && $packet = $this->drain()) {
+            if ($this->options->version === static::EIO_V2 && $packet = $this->drain($this->options->timeout)) {
                 $confirm = null;
                 foreach ($packet->peek(static::PROTO_MESSAGE) as $found) {
                     if ($found->type === static::PACKET_CONNECT) {
@@ -483,7 +483,7 @@ class Version1X extends SocketIO
 
         $this->send(static::PROTO_MESSAGE, static::PACKET_CONNECT . Util::concatNamespace($this->namespace, $this->getAuthPayload()));
 
-        $packet = $this->drain();
+        $packet = $this->drain($this->options->timeout);
         if (true === ($result = $this->getConfirmedNamespace($packet))) {
             return $packet;
         }

--- a/src/Engine/Transport/Polling.php
+++ b/src/Engine/Transport/Polling.php
@@ -331,7 +331,7 @@ class Polling extends Transport
         if (!$data instanceof Encoder) {
             $data = new Encoder($data, $this->sio->getOptions()->version);
         }
-        $options = ['method' => 'POST', 'payload' => $data];
+        $options = ['method' => 'POST', 'payload' => $data, 'timeout' => $this->sio->getOptions()->timeout];
         $headers = $this->getDefaultHeaders();
         $code = 200;
         $transport = isset($parameters['transport']) ? $parameters['transport'] : $this->sio->getOptions()->transport;
@@ -347,7 +347,9 @@ class Polling extends Transport
     public function recv($timeout = 0, $parameters = [])
     {
         $this->timedout = null;
-        $options = [];
+        $options = [
+            'timeout' => $timeout,
+        ];
         if (isset($parameters['upgrade']) && $parameters['upgrade']) {
             $headers = $this->getUpgradeHeaders();
             $options['skip_body'] = true;

--- a/src/Engine/Transport/Polling.php
+++ b/src/Engine/Transport/Polling.php
@@ -347,9 +347,7 @@ class Polling extends Transport
     public function recv($timeout = 0, $parameters = [])
     {
         $this->timedout = null;
-        $options = [
-            'timeout' => $timeout,
-        ];
+        $options = ['timeout' => $timeout];
         if (isset($parameters['upgrade']) && $parameters['upgrade']) {
             $headers = $this->getUpgradeHeaders();
             $options['skip_body'] = true;


### PR DESCRIPTION
Use defined/default timeout for multiple operations to prevent endless hanging requests