### PR TITLE
feat: Introduce umlauts in tests for correct utf-8 handling

### DIFF
--- a/src/Parser/Polling/Decoder.php
+++ b/src/Parser/Polling/Decoder.php
@@ -45,9 +45,9 @@ class Decoder extends ArrayObject
             switch ($eio) {
                 case SocketIO::EIO_V4:
                     if (false !== ($len = $seq->getDelimited(static::EIO_V4_SEPARATOR))) {
-                        $skip = strlen(static::EIO_V4_SEPARATOR);
+                        $skip = mb_strlen(static::EIO_V4_SEPARATOR);
                     } else {
-                        $len = strlen($seq->getData());
+                        $len = mb_strlen($seq->getData());
                     }
                     break;
                 case SocketIO::EIO_V3:
@@ -57,7 +57,7 @@ class Decoder extends ArrayObject
                         if (in_array($signature, ["\x00", "\x01"])) {
                             $len = 0;
                             $sizes = $seq->readUntil("\xff");
-                            $n = strlen($sizes) - 1;
+                            $n = mb_strlen($sizes) - 1;
                             for ($i = 0; $i <= $n; $i++) {
                                 $len += ord($sizes[$i]) * pow(10, $n - $i);
                             }
@@ -70,9 +70,9 @@ class Decoder extends ArrayObject
                     break;
                 case SocketIO::EIO_V1:
                     if (false !== ($len = $seq->getDelimited(static::EIO_V1_SEPARATOR))) {
-                        $skip = strlen(static::EIO_V1_SEPARATOR);
+                        $skip = mb_strlen(static::EIO_V1_SEPARATOR);
                     } else {
-                        $len = strlen($seq->getData());
+                        $len = mb_strlen($seq->getData());
                     }
                     break;
             }

--- a/src/SequenceReader.php
+++ b/src/SequenceReader.php
@@ -47,8 +47,8 @@ class SequenceReader
                 $result = $this->data;
                 $this->data = '';
             } else {
-                $result = substr($this->data, 0, $size);
-                $this->data = substr($this->data, $size);
+                $result = mb_substr($this->data, 0, $size);
+                $this->data = mb_substr($this->data, $size);
             }
 
             return $result;
@@ -67,12 +67,12 @@ class SequenceReader
         if (!$this->isEof()) {
             list($p, $d) = $this->getPos($this->data, $delimiter);
             if (false !== $p) {
-                $result = substr($this->data, 0, $p);
+                $result = mb_substr($this->data, 0, $p);
                 // skip delimiter
                 if (!in_array($d, $noskips)) {
                     $p++;
                 }
-                $this->data = substr($this->data, $p);
+                $this->data = mb_substr($this->data, $p);
 
                 return $result;
             }
@@ -91,8 +91,8 @@ class SequenceReader
         if (!$this->isEof()) {
             list($p, $d) = $this->getPos($this->data, implode(array_merge([$delimiter], $boundaries)));
             if (false !== $p && $d === $delimiter) {
-                $result = substr($this->data, 0, $p);
-                $this->data = substr($this->data, $p);
+                $result = mb_substr($this->data, 0, $p);
+                $this->data = mb_substr($this->data, $p);
 
                 return $result;
             }
@@ -123,9 +123,9 @@ class SequenceReader
     {
         $pos = false;
         $delim = null;
-        for ($i = 0; $i < strlen($delimiter); $i++) {
-            $d = substr($delimiter, $i, 1);
-            if (false !== ($p = strpos($data, $d))) {
+        for ($i = 0; $i < mb_strlen($delimiter); $i++) {
+            $d = mb_substr($delimiter, $i, 1);
+            if (false !== ($p = mb_strpos($data, $d))) {
                 if (false === $pos || $p < $pos) {
                     $pos = $p;
                     $delim = $d;
@@ -153,6 +153,6 @@ class SequenceReader
      */
     public function isEof()
     {
-        return 0 === strlen($this->data) ? true : false;
+        return 0 === mb_strlen($this->data) ? true : false;
     }
 }


### PR DESCRIPTION
Fixes #27 

The error happens with the Polling Decoder if we get multibyte characters (like umlauts) then the `strlen` function will return the wrong string length which results in a broken response from the server.
Sadly I was unable to modify the existing tests to show the incorrect handling :/