### PR TITLE
feat: allow to pass mixed args to emit and ack

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Elephant.io client (`ElephantIO\Client`) provides the following api methods:
 
   Connect to a namespace, see `connect()` above for possible errors.
 
-* `emit($event, array $args, $ack = null)`
+* `emit($event, $args, $ack = null)`
 
   Send an event to server. To request an acknowledgement from server, set `$ack` to `true`.
   When an acknowledgement is requested, a packet will be returned on successful operation.
@@ -232,7 +232,7 @@ Elephant.io client (`ElephantIO\Client`) provides the following api methods:
   Drain and get returned packet from server, used to receive data from server
   when we are not expecting an event to arrive.
 
-* `ack($packet, array $args)`
+* `ack($packet, $args)`
 
   Acknowledge a received event.
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -151,10 +151,10 @@ class Client
      * Acknowledge a packet.
      *
      * @param \ElephantIO\Engine\Packet $packet Packet to acknowledge
-     * @param array $args Acknowledgement data
+     * @param mixed $args Acknowledgement data
      * @return int Number of bytes written
      */
-    public function ack($packet, array $args)
+    public function ack($packet, $args)
     {
         if (null !== $packet->ack) {
             $this->logger->info(sprintf('Acknowledge a packet with id %s', $packet->ack), ['args' => Util::toStr($args)]);

--- a/src/Client.php
+++ b/src/Client.php
@@ -107,13 +107,16 @@ class Client
      * Emit an event to server.
      *
      * @param string $event Event name
-     * @param array $args Event arguments
+     * @param mixed $args Event arguments
      * @param bool $ack Set to true to request acknowledgement
      * @return int|\ElephantIO\Engine\Packet Number of bytes written or acknowledged packet
      */
-    public function emit($event, array $args, $ack = null)
+    public function emit($event, $args, $ack = null)
     {
-        $this->logger->info('Emitting a new event', ['event' => $event, 'args' => Util::toStr($args)]);
+        $this->logger->info('Emitting a new event', [
+            'event' => $event,
+            'args' => Util::toStr($args)
+        ]);
 
         return $this->engine->emit($event, $args, $ack);
     }

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -65,12 +65,12 @@ interface EngineInterface extends LoggerAwareInterface
     /**
      * Emit an event to server.
      *
-     * @param string $event Event to emit
-     * @param array $args Arguments to send
-     * @param bool $ack Set to true to request an ack
+     * @param  string  $event  Event to emit
+     * @param  mixed  $args  Arguments to send
+     * @param  null  $ack  Set to true to request an ack
      * @return int|\ElephantIO\Engine\Packet Number of bytes written or acknowledged packet
      */
-    public function emit($event, array $args, $ack = null);
+    public function emit($event, $args, $ack = null);
 
     /**
      * Wait for event to arrive. To wait for any event from server, simply pass null

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -94,8 +94,8 @@ interface EngineInterface extends LoggerAwareInterface
      * Acknowledge a packet.
      *
      * @param \ElephantIO\Engine\Packet $packet Packet to acknowledge
-     * @param array $args Acknowledgement data
+     * @param mixed $args Acknowledgement data
      * @return int Number of bytes written
      */
-    public function ack($packet, array $args);
+    public function ack($packet, $args);
 }

--- a/src/Engine/SocketIO.php
+++ b/src/Engine/SocketIO.php
@@ -314,9 +314,9 @@ abstract class SocketIO implements EngineInterface, SocketInterface
     }
 
     /** {@inheritDoc} */
-    public function emit($event, array $args, $ack = null)
+    public function emit($event, $args, $ack = null)
     {
-        list($proto, $data, $raws) = $this->createEvent($event, $args, $ack);
+        [$proto, $data, $raws] = $this->createEvent($event, $args, $ack);
 
         $len = $this->send($proto, $data);
         if (is_array($raws)) {

--- a/src/Engine/SocketIO.php
+++ b/src/Engine/SocketIO.php
@@ -361,7 +361,7 @@ abstract class SocketIO implements EngineInterface, SocketInterface
     /** {@inheritDoc} */
     public function ack($packet, array $args)
     {
-        list($proto, $data) = $this->createAck($packet, $args);
+        [$proto, $data] = $this->createAck($packet, $args);
 
         return $this->send($proto, $data);
     }

--- a/src/Engine/SocketIO.php
+++ b/src/Engine/SocketIO.php
@@ -359,7 +359,7 @@ abstract class SocketIO implements EngineInterface, SocketInterface
     }
 
     /** {@inheritDoc} */
-    public function ack($packet, array $args)
+    public function ack($packet, $args)
     {
         [$proto, $data] = $this->createAck($packet, $args);
 

--- a/src/Engine/SocketIO/Version0X.php
+++ b/src/Engine/SocketIO/Version0X.php
@@ -131,7 +131,7 @@ class Version0X extends SocketIO
                     }
                     break;
                 case static::PROTO_ACK:
-                    list($ack, $data) = explode('+', $packet->data, 2);
+                    [$ack, $data] = explode('+', $packet->data, 2);
                     $packet->ack = $ack;
                     $packet->setArgs(json_decode($data, true));
                     break;

--- a/src/Engine/Transport/Polling.php
+++ b/src/Engine/Transport/Polling.php
@@ -170,7 +170,7 @@ class Polling extends Transport
                                     $this->result['status'] = [$matches['HTTP'], (int) $matches['CODE'], $matches['STATUS']];
                                 }
                             } else {
-                                list($key, $value) = explode(':', $content, 2);
+                                [$key, $value] = explode(':', $content, 2);
                                 $value = trim($value);
                                 if (null === $len &&
                                     strtolower($key) === 'content-length') {

--- a/src/Engine/Transport/Websocket.php
+++ b/src/Engine/Transport/Websocket.php
@@ -124,7 +124,7 @@ class Websocket extends Transport
                  * {@link http://stackoverflow.com/questions/14405751/pack-and-unpack-64-bit-integer}
                  */
                 $data .= $bytes = $this->readBytes(8);
-                list($left, $right) = \array_values(\unpack('N2', $bytes));
+                [$left, $right] = \array_values(\unpack('N2', $bytes));
                 $length = $left << 32 | $right;
                 break;
         }

--- a/src/SequenceReader.php
+++ b/src/SequenceReader.php
@@ -65,7 +65,7 @@ class SequenceReader
     public function readUntil($delimiter = ',', $noskips = [])
     {
         if (!$this->isEof()) {
-            list($p, $d) = $this->getPos($this->data, $delimiter);
+            [$p, $d] = $this->getPos($this->data, $delimiter);
             if (false !== $p) {
                 $result = mb_substr($this->data, 0, $p);
                 // skip delimiter
@@ -89,7 +89,7 @@ class SequenceReader
     public function readWithin($delimiter = ',', $boundaries = [])
     {
         if (!$this->isEof()) {
-            list($p, $d) = $this->getPos($this->data, implode(array_merge([$delimiter], $boundaries)));
+            [$p, $d] = $this->getPos($this->data, implode(array_merge([$delimiter], $boundaries)));
             if (false !== $p && $d === $delimiter) {
                 $result = mb_substr($this->data, 0, $p);
                 $this->data = mb_substr($this->data, $p + mb_strlen($d));
@@ -107,7 +107,7 @@ class SequenceReader
      */
     public function getDelimited($delimiter)
     {
-        list($pos, ) = $this->getPos($this->data, $delimiter);
+        [$pos,] = $this->getPos($this->data, $delimiter);
 
         return $pos;
     }

--- a/src/Util.php
+++ b/src/Util.php
@@ -101,7 +101,7 @@ class Util
                 trigger_error('You are using a deprecated header format. Please update to the new key-value array format.', E_USER_DEPRECATED);
                 $newHeaders = [];
                 foreach ($headers as $header) {
-                    list($key, $value) = explode(': ', $header, 2);
+                    [$key, $value] = explode(': ', $header, 2);
                     $newHeaders[$key] = $value;
                 }
                 $headers = $newHeaders; // Convert to new format


### PR DESCRIPTION
Socket.io does not restrict the type of arguments for this functions. Because the library itself limits the type of arguments to array, this makes it incompatible with some applications. For example, Uptime Kuma takes an `int` argument to get data about a monitor: https://github.com/lucasheld/uptime-kuma-api/blob/22ca1813ff8df22ecd694b16c731476b5490af30/uptime_kuma_api/api.py#L1284