### PR TITLE
fix: endless decoding

### DIFF
--- a/src/Parser/Polling/Decoder.php
+++ b/src/Parser/Polling/Decoder.php
@@ -65,7 +65,7 @@ class Decoder extends ArrayObject
                             throw new RuntimeException('Unsupported encoding detected!');
                         }
                     } else {
-                        $len = (int) $seq->readUntil(':');
+                        $len = $seq->readUntil(':');
                     }
                     break;
                 case SocketIO::EIO_V1:


### PR DESCRIPTION
If ```$data``` in `$seq` is for example `Welcome to socket.io.` then the decoding will never end. 
In line 79 is the exit condition, but was never reached because of the type-conversion