### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+phpunit.xml export-ignore
+/.github export-ignore
+/example export-ignore
+/test export-ignore


### PR DESCRIPTION
Hello,

This PR adds a `.gitattributes` file so some files/directories are not downloaded when installing the package with composer.

It is documented here: https://getcomposer.org/doc/02-libraries.md#light-weight-distribution-packages